### PR TITLE
fix(firefox): dynamic chart - pass data with custom event

### DIFF
--- a/scripts/dynamic-chart-core.js
+++ b/scripts/dynamic-chart-core.js
@@ -257,7 +257,7 @@ function dcIndices(startMoney = 10000, startIndex = 0) {
 
   yearPicker.addEventListener("click", function (event) {
     startYearControl.value = event.target.dataset.value;
-    startYearControl.dispatchEvent(new Event("change"));
+    startYearControl.dispatchEvent(new CustomEvent("change", { detail: event.target.dataset.value }));
   });
 
 
@@ -266,7 +266,7 @@ function dcIndices(startMoney = 10000, startIndex = 0) {
     debounce(600, (event) => {
       // hide year-picker list
       startYearControl.blur();
-      const year = event.path[0].value;
+      const year = event.detail;
       const startIndex = data.findIndex((row) => row[0].endsWith(year)); // picks first trading day of selected year
 
       if (startIndex > -1) {

--- a/scripts/dynamic-chart.js
+++ b/scripts/dynamic-chart.js
@@ -88,32 +88,6 @@ class DynamicChart extends HTMLElement {
       }
     }
     
-    
-    #chart-dialog {
-      padding: 1rem 2rem;
-      border-radius: 4px;
-      box-shadow: 2px 2px 6px rgba(0, 0, 0, 0.25);
-      position: fixed;
-      z-index: 6;
-      width: 75vw;
-      margin: 100px auto;
-      overflow-y: auto;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-    }
-    
-    #chart-dialog button {
-      background-color: #ff6b35;
-      border: none;
-      color: #fff;
-      padding: 15px 20px;
-      text-decoration: none;
-      text-align: center;
-      cursor: pointer;
-    }
-    
     label[for="start-year"] {
       position: relative;
     }
@@ -135,6 +109,7 @@ class DynamicChart extends HTMLElement {
       list-style: none;
       grid-template-columns: 1fr 1fr 1fr;
       grid-template-rows: auto;
+      padding-inline: 0;
     }
     
     #year-picker li {


### PR DESCRIPTION
Fix für Dynamic Chart YearPicker in Firefox